### PR TITLE
Song Format Rewrite

### DIFF
--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -300,6 +300,42 @@ class Paths
 		return file;
 	}
 
+	/*
+	* NEW SONG FILE FORMAT
+	*
+	* "diff" allows you to add remixes of a song under the same folder, for example, an erect remix.
+	*
+	* Opponent & Player Voices are separate to add some quality of life to the music, especially during duels
+	* when you're missing like fucking crazy for some reason.
+	*
+	* @author DEMOLITIONDON96
+	*/
+	inline static public function voicesPlayer(song:String, diff:String = 'normal'):Any
+	{
+		var songKey:String = '${CoolUtil.swapSpaceDash(song.toLowerCase())}/Voices-${diff}';
+		var voices = returnSound('songs', songKey);
+		return voices;
+	}
+	
+	inline static public function voicesOpp(song:String, diff:String = 'normal'):Any
+	{
+		var songKey:String = '${CoolUtil.swapSpaceDash(song.toLowerCase())}/VoicesOpp-${diff}';
+		var voices = returnSound('songs', songKey);
+		return voices;
+	}
+	
+	inline static public function instNew(song:String, diff:String = 'normal'):Any
+	{
+		var songKey:String = '${CoolUtil.swapSpaceDash(song.toLowerCase())}/Inst-${diff}';
+		var inst = returnSound('songs', songKey);
+		return inst;
+	}
+	
+	/*
+	* LEGACY SONG FORMATS
+	*
+	* The original engine's song format for those that would rather use this.
+	*/
 	inline static public function voices(song:String):Any
 	{
 		var songKey:String = '${CoolUtil.swapSpaceDash(song.toLowerCase())}/Voices';

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1654,7 +1654,7 @@ class PlayState extends MusicBeatState
 		if (songMusic != null)
 			songMusic.stop();
 		
-		if (songMusicNew !- null)
+		if (songMusicNew != null)
 			songMusicNew.stop();
 		
 		if (bf_vocals != null)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1671,7 +1671,7 @@ class PlayState extends MusicBeatState
 	{
 		if (paused)
 		{
-			if (songMusic != null)
+			if (songMusic != null || songMusic != null)
 			{
 				songMusic.pause();
 				songMusicNew.pause();

--- a/source/states/editors/OriginalChartingState.hx
+++ b/source/states/editors/OriginalChartingState.hx
@@ -594,7 +594,7 @@ class OriginalChartingState extends MusicBeatState
 			opp_vocals.stop();
 
 		songMusic = new FlxSound().loadEmbedded(Paths.inst(daSong), false, true);
-		songMusicNew = new FlxSound().loadEmbedded(Paths.instNew(daSong, CoolUtil.difficultyString.toLowerCase()), false, true);;
+		songMusicNew = new FlxSound().loadEmbedded(Paths.instNew(daSong, CoolUtil.difficultyString.toLowerCase()), false, true);
 		if (_song.needsVoices)
 		{
 			vocals = new FlxSound().loadEmbedded(Paths.voices(daSong), false, true);

--- a/source/states/editors/OriginalChartingState.hx
+++ b/source/states/editors/OriginalChartingState.hx
@@ -261,7 +261,7 @@ class OriginalChartingState extends MusicBeatState
 			}
 		};
 		
-		var check_mute_vocals_bf = new FlxUICheckBox(check_mute_inst.x + 120, check_mute_inst.y - 25, null, null, "Mute Player Vocals (in editor)", 100);
+		var check_mute_vocals_bf = new FlxUICheckBox(check_mute_inst.x + 120, check_mute_inst.y + 22, null, null, "Mute Player Vocals (in editor)", 100);
 		check_mute_vocals_bf.checked = false;
 		check_mute_vocals_bf.callback = function()
 		{


### PR DESCRIPTION
Basically, this changes the way songs will load

What this adds:

- The ability to add difficulty suffix to your song files without making a new folder (ex: "Inst-erect")
- Have bf and opponent voices separated (this helps a lot with those duel sections of the songs)
- does NOT override already existing song format, allowing you to still use the already existing one if you still prefer it
- adds 2 new options to the chart editor for the new song format stuff ("Mute Player Vocals" & "Mute Opponent Vocals")

This probably won't get merged, but it's just an idea I had :)